### PR TITLE
Update memory layout and quaternion compression

### DIFF
--- a/src/sogs/sogs_compression.py
+++ b/src/sogs/sogs_compression.py
@@ -310,7 +310,6 @@ def read_ply(path):
         return col_name in vd.dtype.names
 
     xyz = np.stack([vd['x'], vd['y'], vd['z']], axis=-1)
-    normals = np.stack([vd['nx'], vd['ny'], vd['nz']], axis=-1)
     f_dc = np.stack([vd[f"f_dc_{i}"] for i in range(3)], axis=-1)
 
     rest_cols = [c for c in vd.dtype.names if c.startswith('f_rest_')]


### PR DESCRIPTION
This PR makes the following changes:
- pack alpha into sh0.a output
- update quaternion packing strategy to use the "exclude largest component" method
    - index of the largest component is stored in quats.a (values 252, 253, 254, 255)
    - quats.rgb contains the 3 smaller components, in order
- combine labels_l and labels_u into single texture's r and g channel